### PR TITLE
feat: change value category top page from db

### DIFF
--- a/app/template/default/Block/category.twig
+++ b/app/template/default/Block/category.twig
@@ -1,0 +1,26 @@
+{% set Categories = repository('Eccube\\Entity\\Category').getList() %}
+
+{% macro renderCategoryItem(Category) %}
+    <div class="ec-categoryRole__listItem">
+        <a href="{{ url('product_list', { category_id: Category.id }) }}">
+            <img src="{{ asset('assets/img/top/fpo_355x150.png') }}" alt="{{ Category.name }}">
+        </a>
+    </div>
+{% endmacro %}
+
+{% from _self import renderCategoryItem %}
+
+<div class="ec-categoryRole">
+    <div class="ec-role">
+        <div class="ec-secHeading">
+            <span class="ec-secHeading__en">{{ 'front.block.category.category__en'|trans }}</span>
+            <span class="ec-secHeading__line"></span>
+            <span class="ec-secHeading__ja">{{ 'front.block.category.category__ja'|trans }}</span>
+        </div>
+        <div class="ec-categoryRole__list">
+            {% for Category in Categories %}
+                {{ renderCategoryItem(Category) }}
+            {% endfor %}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
1. Mục đích: Sửa lại giao diện cũ của Category ở màn hình Top.
Hiện tại: Category ở trang Top đang được fix cứng dữ liệu.
Sửa lại: đổ dữ liệu category từ DB.
2. Hướng giải quyết:
Category được code từ: `src/Eccube/Resource/template/default/Block/category.twig`
Không sửa trực tiếp vào file này vì đang nằm trong folder Eccube khi update version sẽ bị mất code.
=> Thay vào đó tạo file `app/template/default/Block/category.twig`, cần phải tạo đúng folder và tên thì Ec-Cube sẽ tự động ghi đè nên Category của folder Eccube.
